### PR TITLE
Organized dump folder

### DIFF
--- a/CTFAK.Decompiler/FTDecompile.cs
+++ b/CTFAK.Decompiler/FTDecompile.cs
@@ -403,7 +403,8 @@ namespace CTFAK.Tools
                 Logger.Log($"Translating frame {frame.name} - {a}");
                 mfa.Frames.Add(newFrame);
             }
-            mfa.Write(new ByteWriter(new FileStream($"Dumps\\{Path.GetFileNameWithoutExtension(game.editorFilename)}.mfa", FileMode.Create)));
+            Directory.CreateDirectory($"Dumps\\{mfa.Name}");
+            mfa.Write(new ByteWriter(new FileStream($"Dumps\\{mfa.Name}\\{Path.GetFileNameWithoutExtension(game.editorFilename)}.mfa", FileMode.Create)));
         }
 
         public static MFATransition ConvertTransition(Transition gameTrans)

--- a/CTFAK/EXE/PackData.cs
+++ b/CTFAK/EXE/PackData.cs
@@ -82,7 +82,7 @@ namespace CTFAK.EXE
         public void Read(ByteReader exeReader)
         {
             UInt16 len = exeReader.ReadUInt16();
-            PackFilename = exeReader.ReadWideString(len);
+            PackFilename = "TestName"; //exeReader.ReadWideString(len);
             _bingo = exeReader.ReadInt32();
             Data = exeReader.ReadBytes(exeReader.ReadInt32());
 

--- a/CTFAK/EXE/PackData.cs
+++ b/CTFAK/EXE/PackData.cs
@@ -82,7 +82,7 @@ namespace CTFAK.EXE
         public void Read(ByteReader exeReader)
         {
             UInt16 len = exeReader.ReadUInt16();
-            PackFilename = "TestName"; //exeReader.ReadWideString(len);
+            PackFilename = exeReader.ReadWideString(len);
             _bingo = exeReader.ReadInt32();
             Data = exeReader.ReadBytes(exeReader.ReadInt32());
 

--- a/Dumper/SimpleDumper.cs
+++ b/Dumper/SimpleDumper.cs
@@ -31,7 +31,7 @@ namespace Dumper
         public void Execute(IFileReader reader)
         {
             var images = reader.getGameData().images.Items;
-            var outPath = Path.GetFileNameWithoutExtension(reader.getGameData().targetFilename) ?? "dummyGame";
+            var outPath = reader.getGameData().name ?? "Unknown Game";
             Directory.CreateDirectory($"Dumps\\{outPath}\\Images");
             Task[] tasks = new Task[images.Count];
             int i = 0;
@@ -65,13 +65,11 @@ namespace Dumper
         public void Execute(IFileReader reader)
         {
             var sounds = reader.getGameData().Sounds.Items;
-            var outPath = Path.GetFileNameWithoutExtension(reader.getGameData().targetFilename) ?? "dummyGame";
+            var outPath = reader.getGameData().name ?? "Unknown Game";
             Directory.CreateDirectory($"Dumps\\{outPath}\\Sounds");
             foreach (var snd in sounds)
             {
-
-                    File.WriteAllBytes($"Dumps\\{outPath}\\Sounds\\{Utils.ClearName(snd.Name)}{getExtension(snd.Data)}", snd.Data);
-
+                File.WriteAllBytes($"Dumps\\{outPath}\\Sounds\\{Utils.ClearName(snd.Name)}{getExtension(snd.Data)}", snd.Data);
             }
         }
     }

--- a/Dumper/SortedImageDumper.cs
+++ b/Dumper/SortedImageDumper.cs
@@ -17,7 +17,7 @@ namespace Dumper
 
         public void Execute(IFileReader reader)
         {
-            var outPath = Path.GetFileNameWithoutExtension(reader.getGameData().targetFilename) ?? "dummyGame";
+            var outPath = reader.getGameData().name ?? "Unknown Game";
             var images = reader.getGameData().images.Items;
             var frames = reader.getGameData().frames;
             var objects = reader.getGameData().frameitems;
@@ -33,17 +33,17 @@ namespace Dumper
                     if (oi.properties is Backdrop bg)
                     {
                         Directory.CreateDirectory(objectFolder);
+                        Directory.CreateDirectory($"{frameFolder}{{unsorted}}");
                         images[bg.Image]?.bitmap.Save(objectFolder + "0.png");
-                        images[bg.Image]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
-                        images[bg.Image]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                        images[bg.Image]?.bitmap.Save($"{frameFolder}{{unsorted}}\\{imageNumber}.png");
                         imageNumber++;
                     }
                     else if (oi.properties is Quickbackdrop qbg)
                     {
                         Directory.CreateDirectory(objectFolder);
+                        Directory.CreateDirectory($"{frameFolder}{{unsorted}}");
                         images[qbg.Image]?.bitmap.Save(objectFolder + "0.png");
-                        images[qbg.Image]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
-                        images[qbg.Image]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                        images[qbg.Image]?.bitmap.Save($"{frameFolder}{{unsorted}}\\{imageNumber}.png");
                         imageNumber++;
                     }
                     else if(oi.properties is ObjectCommon common)
@@ -83,9 +83,9 @@ namespace Dumper
                                     {
                                         var frm = frms[i];
                                         Directory.CreateDirectory(directionFolder);
+                                        Directory.CreateDirectory($"{frameFolder}{{unsorted}}");
                                         images[frm]?.bitmap.Save($"{directionFolder}{frm}.png");
-                                        images[frm]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
-                                        images[frm]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                                        images[frm]?.bitmap.Save($"{frameFolder}{{unsorted}}\\{imageNumber}.png");
                                         imageNumber++;
                                     }
                                 }
@@ -98,10 +98,9 @@ namespace Dumper
                             foreach (var cntrFrm in counter.Frames)
                             {
                                 Directory.CreateDirectory(objectFolder);
-
+                                Directory.CreateDirectory($"{frameFolder}{{unsorted}}");
                                 images[cntrFrm]?.bitmap.Save($"{objectFolder}{cntrFrm}.png");
-                                images[cntrFrm]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
-                                images[cntrFrm]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                                images[cntrFrm]?.bitmap.Save($"{frameFolder}{{unsorted}}\\{imageNumber}.png");
                                 imageNumber++;
                             }
                         }

--- a/Dumper/SortedImageDumper.cs
+++ b/Dumper/SortedImageDumper.cs
@@ -13,6 +13,7 @@ namespace Dumper
     class SortedImageDumper : IFusionTool
     {
         public string Name => "Sorted Image Dumper";
+        int imageNumber = 0;
 
         public void Execute(IFileReader reader)
         {
@@ -33,11 +34,17 @@ namespace Dumper
                     {
                         Directory.CreateDirectory(objectFolder);
                         images[bg.Image]?.bitmap.Save(objectFolder + "0.png");
+                        images[bg.Image]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
+                        images[bg.Image]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                        imageNumber++;
                     }
                     else if (oi.properties is Quickbackdrop qbg)
                     {
                         Directory.CreateDirectory(objectFolder);
                         images[qbg.Image]?.bitmap.Save(objectFolder + "0.png");
+                        images[qbg.Image]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
+                        images[qbg.Image]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                        imageNumber++;
                     }
                     else if(oi.properties is ObjectCommon common)
                     {
@@ -77,6 +84,9 @@ namespace Dumper
                                         var frm = frms[i];
                                         Directory.CreateDirectory(directionFolder);
                                         images[frm]?.bitmap.Save($"{directionFolder}{frm}.png");
+                                        images[frm]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
+                                        images[frm]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                                        imageNumber++;
                                     }
                                 }
                             }
@@ -90,6 +100,9 @@ namespace Dumper
                                 Directory.CreateDirectory(objectFolder);
 
                                 images[cntrFrm]?.bitmap.Save($"{objectFolder}{cntrFrm}.png");
+                                images[cntrFrm]?.bitmap.Save($"{frameFolder}unsorted\\{imageNumber}.png");
+                                images[cntrFrm]?.bitmap.Save($"Dumps\\{outPath}\\Sorted Images\\unsorted\\{imageNumber}.png");
+                                imageNumber++;
                             }
                         }
                     }


### PR DESCRIPTION
MFAs, Images, Sounds, and Sorted Images now get saved to "root\dump\Game Name\"

Also added Unsorted folders in Sorted Images but only in each frame ("Sorted Images\Frame 1\{Unsorted}").
Makes it easier to find what you're looking for rather than go into a random folder named "Active"